### PR TITLE
Fix: Ensure bash shell is used in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -23,6 +23,7 @@ jobs:
       run: |
         latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
         echo "::set-output name=latest_tag::$latest_tag"
+      shell: bash
 
     - name: Calculate new version
       id: calc_new_version
@@ -34,12 +35,15 @@ jobs:
           new_version=$(echo $latest_tag | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
         fi
         echo "::set-output name=new_version::$new_version"
+      shell: bash
 
     - name: Create tag
       run: git tag -a "${{ steps.calc_new_version.outputs.new_version }}" -m "Release ${{ steps.calc_new_version.outputs.new_version }}"
+      shell: bash
 
     - name: Push tag to GitHub
       run: git push origin "${{ steps.calc_new_version.outputs.new_version }}"
+      shell: bash
 
     - name: Create GitHub Release
       uses: actions/create-release@v1


### PR DESCRIPTION
Explicitly set the shell to bash in the create-release workflow to prevent issues with environment variables and command execution. This ensures consistent behavior across different GitHub Actions environments.