### PR TITLE
Fix: Use latest tag for release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Get the latest tag
       id: get_latest_tag
       run: |
-        latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+        latest_tag=$(git describe --tags)
         echo "Latest tag: $latest_tag"
         echo "::set-output name=latest_tag::$latest_tag"
       shell: bash


### PR DESCRIPTION
The previous logic for fetching the latest tag was incorrect. This commit updates the workflow to use the latest tag directly, ensuring accurate release creation.