### PR TITLE
Fix: Release workflow gets latest tag without version number

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Get the latest tag
       id: get_latest_tag
       run: |
-        latest_tag=$(git describe --tags)
+        latest_tag=$(git describe --tags --abbrev=0)
         echo "Latest tag: $latest_tag"
         echo "::set-output name=latest_tag::$latest_tag"
       shell: bash


### PR DESCRIPTION
The `git describe` command was previously returning the latest tag with the version number. This commit updates the command to only return the latest tag name, ensuring accurate release creation.