### PR TITLE
Fix: Enable release creation workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # - name: Set up Git
-      #   run: |
-      #     git config --global user.name "github-actions[bot]"
-      #     git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - uses: paulhatch/semantic-version@v5.3.0
         id: generate-version


### PR DESCRIPTION
Enables the release creation workflow by removing comments that were preventing the `git config` commands from running. This allows for automated releases to be created from the workflow.