### PR TITLE
Fix: Use consistent version regex for release creation

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -29,5 +29,6 @@ jobs:
         id: create-release
         uses: undergroundwires/bump-everywhere@1.4.0
         with:
+          version_regex: "st4-(MAJOR).(MINOR).(PATCH)"
           git-token: ${{ secrets.ACTION_TOKEN }}
           release-token: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION
Update the release workflow to use a consistent version regex for generating release tags, ensuring proper versioning across the project. This addresses an inconsistency that caused incorrect release creation.