### PR TITLE
Fix: Update release workflow to use consistent versioning

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: paulhatch/semantic-version@v5.3.0
         id: generate-version
         with:
+          tag_prefix: "st4-"
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
           version_format: "st4-${major}.${minor}.${patch}"
@@ -29,6 +30,5 @@ jobs:
         id: create-release
         uses: undergroundwires/bump-everywhere@1.4.0
         with:
-          version_regex: "st4-(MAJOR).(MINOR).(PATCH)"
           git-token: ${{ secrets.ACTION_TOKEN }}
           release-token: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION
The release workflow has been updated to use a consistent `st4-` prefix for all versions. This ensures that releases are properly tagged and identified.