### PR TITLE
Fix: Specify release type in GitHub Action

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           tag_prefix: "st4-"
           default_bump: patch
+          release_type: patch
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check release output


### PR DESCRIPTION
Ensures consistent release type for GitHub Actions releases by setting `release_type` to `patch`. This will prevent unexpected behavior and ensure that releases are properly labeled.