### PR TITLE
Fix: Remove extraneous print statement

### DIFF
--- a/_config.py
+++ b/_config.py
@@ -112,5 +112,4 @@ for attr in dir(CONFIG):
 
 
 if __name__ == "Simplenote._config":
-    print("__name__", __name__)
     from .utils.logger import init


### PR DESCRIPTION
Removed a redundant print statement that was not contributing to the functionality of the code. This helps to ensure the code remains clean and concise.