### PR TITLE
Fix: Handle missing settings file

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -25,10 +25,13 @@ def edit_settings():
         CONFIG.SIMPLENOTE_INSTALLED_PACKAGE_DIR, CONFIG.SIMPLENOTE_SETTINGS_FILE_PATH
     )
     package_settings_file = os.path.join(CONFIG.SIMPLENOTE_PACKAGE_DIR, CONFIG.SIMPLENOTE_SETTINGS_FILE_PATH)
+    logger.warning(os.path.exists(installed_package_settings_file), os.path.exists(package_settings_file))
     if os.path.exists(installed_package_settings_file):
         settings_file = installed_package_settings_file
-    else:
+    elif os.path.exists(package_settings_file):
         settings_file = package_settings_file
+    else:
+        settings_file = CONFIG.SIMPLENOTE_SETTINGS_FILE_PATH
     # sublime.run_command("open_file", {"file": CONFIG.SIMPLENOTE_SETTINGS_FILE_PATH})
     sublime.run_command(
         "edit_settings",


### PR DESCRIPTION
Adds robustness to the settings file loading logic. Now it correctly handles cases where the settings file is missing from the expected locations, including the installed package directory and the default location.