### PR TITLE
Fix: Logging of settings file paths

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -25,7 +25,8 @@ def edit_settings():
         CONFIG.SIMPLENOTE_INSTALLED_PACKAGE_DIR, CONFIG.SIMPLENOTE_SETTINGS_FILE_PATH
     )
     package_settings_file = os.path.join(CONFIG.SIMPLENOTE_PACKAGE_DIR, CONFIG.SIMPLENOTE_SETTINGS_FILE_PATH)
-    logger.warning((os.path.exists(installed_package_settings_file), os.path.exists(package_settings_file)))
+    logger.warning((os.path.exists(installed_package_settings_file), installed_package_settings_file))
+    logger.warning((os.path.exists(package_settings_file), package_settings_file))
     if os.path.exists(installed_package_settings_file):
         settings_file = installed_package_settings_file
     elif os.path.exists(package_settings_file):


### PR DESCRIPTION
Add explicit logging of the full path for both installed and default settings files. This helps better debug potential issues with settings file location.