### PR TITLE
Fix: Truncate long note bodies in quick panel

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -221,7 +221,7 @@ def show_quick_panel(first_sync: bool = False):
             note,
             note.title,
             [
-                note.body,
+                note.body[:120] + "..." if len(note.body) > 120 else note.body,
                 # f"tags: {note.d.tags}",
             ],  # type: ignore
             f"version:{note.v} | update:{datetime.fromtimestamp(note.d.modificationDate).strftime('%Y-%m-%d %H:%M:%S')}",


### PR DESCRIPTION
The note body in the quick panel was not truncated when it exceeded a certain length, making it difficult to read. This commit truncates the note body to 120 characters and appends an ellipsis if necessary.